### PR TITLE
Feature/allow more security handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,5 +72,36 @@ Specifications is the OpenAPI spec.
 Url is the current url.
 
 
+## Add custom security handlers like JWT
+```javascript
+import jwt from 'jsonwebtoken'
+
+function jwtHandler(context, request, response) {
+  const authHeader = context.request.headers.authorization;
+  if (!authHeader) {
+    throw new Error('Missing authorization header');
+  }
+  const token = authHeader.replace('Bearer ', '');
+  return jwt.verify(token, 'secret');
+}
+
+const securityHandlers = [
+  {
+    name: 'jwt',
+    handler: jwtHandler
+  }
+]
+
+const api = new Api({
+  version: 'v1',
+  specification: openAPISpecification,
+  controllers,
+  securityHandlers
+})
+```
+
+See also: https://openapistack.co/docs/openapi-backend/security-handlers/#security-handlers
+
+
 [npm-url]: https://www.npmjs.com/package/@hckrnews/openapi-server
 [npm-image]: https://img.shields.io/npm/v/@hckrnews/openapi-server.svg

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@hckrnews/openapi-server",
-    "version": "0.8.11",
+    "version": "0.8.12",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@hckrnews/openapi-server",
-            "version": "0.8.11",
+            "version": "0.8.12",
             "license": "MIT",
             "dependencies": {
                 "@sentry/node": "^7.86.0",
@@ -29,7 +29,7 @@
                 "eslint-plugin-jsdoc": "^48.0.0",
                 "eslint-plugin-n": "^16.0.0",
                 "eslint-plugin-promise": "^6.0.1",
-                "eslint-plugin-sonarjs": "^0.24.0",
+                "eslint-plugin-sonarjs": "^0.25.1",
                 "jscpd": "^3.2.1",
                 "supertest": "^6.3.3"
             },
@@ -557,9 +557,9 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "20.12.4",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.4.tgz",
-            "integrity": "sha512-E+Fa9z3wSQpzgYQdYmme5X3OTuejnnTx88A6p6vkkJosR3KBz+HpE3kqNm98VE6cfLFcISx7zW7MsJkH6KwbTw==",
+            "version": "20.12.7",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.7.tgz",
+            "integrity": "sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==",
             "dev": true,
             "dependencies": {
                 "undici-types": "~5.26.4"
@@ -987,9 +987,9 @@
             }
         },
         "node_modules/builtins": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
-            "integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.1.0.tgz",
+            "integrity": "sha512-SW9lzGTLvWTP1AY8xeAMZimqDrIaSdLQUcVr9DMef51niJ022Ri87SwRRKYm4A6iHfkPaiVUu/Duw2Wc4J7kKg==",
             "dev": true,
             "dependencies": {
                 "semver": "^7.0.0"
@@ -1992,9 +1992,9 @@
             }
         },
         "node_modules/eslint-plugin-html": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-html/-/eslint-plugin-html-8.0.0.tgz",
-            "integrity": "sha512-NINLBAXM3mLa3k5Ezr/kNLHAJJwbot6lS7Ro+SUftDw4cA51KMmcDuCf98GP6Q6kTVPY1hIggzskxAdxfUPXSA==",
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-html/-/eslint-plugin-html-8.1.0.tgz",
+            "integrity": "sha512-5bRZQwxZew2Yo9Fa8diz2C9RmzIw9Gs4yzmmjUcpuzhdLW8aVcDtYzEHhNNdt01Z0m4AzSJNuY63RXvzStvDgA==",
             "dev": true,
             "peer": true,
             "dependencies": {
@@ -2211,9 +2211,9 @@
             }
         },
         "node_modules/eslint-plugin-sonarjs": {
-            "version": "0.24.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-0.24.0.tgz",
-            "integrity": "sha512-87zp50mbbNrSTuoEOebdRQBPa0mdejA5UEjyuScyIw8hEpEjfWP89Qhkq5xVZfVyVSRQKZc9alVm7yRKQvvUmg==",
+            "version": "0.25.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-0.25.1.tgz",
+            "integrity": "sha512-5IOKvj/GMBNqjxBdItfotfRHo7w48496GOu1hxdeXuD0mB1JBlDCViiLHETDTfA8pDAVSBimBEQoetRXYceQEw==",
             "dev": true,
             "engines": {
                 "node": ">=16"
@@ -5151,9 +5151,9 @@
             }
         },
         "node_modules/swagger-ui-dist": {
-            "version": "5.13.0",
-            "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.13.0.tgz",
-            "integrity": "sha512-uaWhh6j18IIs5tOX0arvIBnVINAzpTXaQXkr7qAk8zoupegJVg0UU/5+S/FgsgVCnzVsJ9d7QLjIxkswEeTg0Q=="
+            "version": "5.15.0",
+            "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.15.0.tgz",
+            "integrity": "sha512-1zd4cNaUayXCWFSdBGNB+CYGISbe7M4FSgPqOjrgqKi1oEZfXzrOrjIHa0jHf5uSDN0X/mXmhFgKR9Jrr+fvqQ=="
         },
         "node_modules/swagger-ui-express": {
             "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@hckrnews/openapi-server",
     "description": "OpenAPI Server",
-    "version": "0.8.11",
+    "version": "0.8.12",
     "author": {
         "name": "Pieter Wigboldus",
         "url": "https://hckr.news/"
@@ -42,7 +42,7 @@
         "eslint-plugin-jsdoc": "^48.0.0",
         "eslint-plugin-n": "^16.0.0",
         "eslint-plugin-promise": "^6.0.1",
-        "eslint-plugin-sonarjs": "^0.24.0",
+        "eslint-plugin-sonarjs": "^0.25.1",
         "jscpd": "^3.2.1",
         "supertest": "^6.3.3"
     },

--- a/src/__fixtures__/spec.json
+++ b/src/__fixtures__/spec.json
@@ -144,6 +144,32 @@
                     }
                 ]
             }
+        },
+        "/user-secure": {
+            "get": {
+                "operationId": "getUserSecure",
+                "summary": "Get all user record",
+                "description": "Get the user record from the database.",
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {}
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "tags": [
+                    "Example"
+                ],
+                "security": [
+                    {
+                        "customSecurityHandler": []
+                    }
+                ]
+            }
         }
     },
     "info": {

--- a/src/api.js
+++ b/src/api.js
@@ -3,11 +3,15 @@ import swaggerUi from 'swagger-ui-express'
 import { setupRouter } from './router.js'
 
 /**
+ * @typedef {import('openapi-backend').Handler} Handler
  * @typedef {object} Logger
  * @property {Function} error
  * @property {Function} warn
  * @property {Function} info
  * @property {Function} debug
+ * @typedef {object} SecurityHandler
+ * @property {string} name
+ * @property {Handler} handler
  * @typedef {object} ApiSchema
  * @property {string} version
  * @property {object} specification
@@ -18,6 +22,7 @@ import { setupRouter } from './router.js'
  * @property {boolean=} errorDetails
  * @property {Logger=} logger
  * @property {object=} meta
+ * @property {SecurityHandler[]=} securityHandlers
  */
 
 /**
@@ -28,7 +33,7 @@ export class Api {
   /**
    * @param {ApiSchema} params
    */
-  constructor ({ version, specification, controllers, secret, apiRoot, strictSpecification, errorDetails, logger, meta }) {
+  constructor ({ version, specification, controllers, secret, apiRoot, strictSpecification, errorDetails, logger, meta, securityHandlers }) {
     this.version = version
     this.specification = specification
     this.controllers = controllers
@@ -38,6 +43,7 @@ export class Api {
     this.errorDetails = errorDetails || false
     this.logger = logger || console
     this.meta = meta || {}
+    this.securityHandlers = securityHandlers || []
   }
 
   setup () {
@@ -56,7 +62,8 @@ export class Api {
       strictSpecification: this.strictSpecification,
       errorDetails: this.errorDetails,
       logger: this.logger,
-      meta: this.meta
+      meta: this.meta,
+      securityHandlers: this.securityHandlers
     })
     api.init()
 

--- a/src/router.js
+++ b/src/router.js
@@ -9,6 +9,7 @@ import { unauthorized } from './handlers/unauthorized.js'
 
 /**
  * @typedef {import('./api.js').Logger} Logger
+ * @typedef {import('./api.js').SecurityHandler} SecurityHandler
  * Setup the router
  * @param {object} params
  * @param {string=} params.secret
@@ -19,9 +20,10 @@ import { unauthorized } from './handlers/unauthorized.js'
  * @param {boolean=} params.errorDetails
  * @param {Logger=} params.logger
  * @param {object=} params.meta
+ * @param {SecurityHandler[]=} params.securityHandlers
  * @returns {{ api, openAPISpecification: object }}
  */
-export const setupRouter = ({ secret, openAPISpecification, controllers, apiRoot, strictSpecification, errorDetails, logger, meta }) => {
+export const setupRouter = ({ secret, openAPISpecification, controllers, apiRoot, strictSpecification, errorDetails, logger, meta, securityHandlers = [] }) => {
   const api = new OpenAPIBackend({
     definition: openAPISpecification,
     apiRoot,
@@ -66,6 +68,10 @@ export const setupRouter = ({ secret, openAPISpecification, controllers, apiRoot
     'apiKey',
     (context) => context.request.headers['x-api-key'] === secret
   )
+
+  securityHandlers.forEach((securityHandler) => {
+    api.registerSecurityHandler(securityHandler.name, securityHandler.handler)
+  })
 
   return { api, openAPISpecification }
 }


### PR DESCRIPTION
See: https://openapistack.co/docs/openapi-backend/security-handlers/#security-handlers

Usage:
```javascript
import jwt from 'jsonwebtoken'

function jwtHandler(c, req, res) {
  const authHeader = c.request.headers.authorization;
  if (!authHeader) {
    throw new Error('Missing authorization header');
  }
  const token = authHeader.replace('Bearer ', '');
  return jwt.verify(token, 'secret');
}

const securityHandlers = [
  {
    name: 'jwt',
    handler: jwtHandler
  }
]

const api = new Api({
  version: 'v1',
  specification: openAPISpecification,
  controllers,
  securityHandlers
})
```

And in the controller, you can get the value from the security handler.
E.g. `context.security.jwt` for this example.
See also the `openapi-backend` documentation.